### PR TITLE
fix: solve commit-msg issue

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-header=$(sed -n '1p' "$1")
-echo "$header" | grep -qE "^(feat|fix|docs|refactor)(\([a-z0-9_]{1,20}\))?: [a-z].{0,78}[^\.[:space:]]$" || exit 1
-newline=$(sed -n '2p' "$1")
-echo "$newline" | grep -qE "^$" || exit 1
-bodystart=$(sed -n '3p' "$1")
-echo "$bodystart" | grep -qE "[[:print:]]" || exit 1
-#espace fin ligne
+HEADER=$(sed -n '1p' "$1")
+NEWLINE=$(sed -n '2p' "$1")
+HEADER_REGEXP="^(feat|fix|docs|refactor)"`
+             `"(\([a-z0-9_]{1,20}\))?: "`
+             `"[a-z].{0,78}[^\.[:space:]]$"
+
+echo "$HEADER"  | grep -qE "$HEADER_REGEXP" || exit 1
+echo "$NEWLINE" | grep -qE "^$"             || exit 1
 


### PR DESCRIPTION
- How do you like your scripts?
- I like mine aligned.

Now the shell script is simpler. But you gain the ability to do something like:
```
feat: update file


Update file
```
(with two newlines, or more). But please don't.


However, exit code is 1 for basic typos like:
```
feet: update file
```
And for skipping the newline:
```
feat: update file
- Update file
```


